### PR TITLE
feat: onReady argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ import Controller from '@ember/controller';
 
 export default class Application extends Controller {
   sample1 = "let x: string = 'foo'";
+
+  @action
+  editorReady (editor) {
+    // editor: Monaco editor instance
+  }
 }
 ```
 
@@ -31,6 +36,7 @@ export default class Application extends Controller {
   code=sample1
   onChange=(action (mut sample1))
   theme="light"
+  onReady=(action editorReady)
 }}
 ```
 

--- a/addon/components/code-editor.ts
+++ b/addon/components/code-editor.ts
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import Penpal, { IChildConnectionObject } from 'penpal';
+import * as mon from 'monaco-editor';
 
 export interface CodeEditorKeyCommand {
   cmd?: boolean;
@@ -16,6 +17,7 @@ export default class CodeEditor extends Component {
   public theme: 'vs-dark' | 'vs-light' = 'vs-dark'; // TODO: proper default value
   public onChange?: (v: string) => any;
   public onKeyCommand?: (evt: CodeEditorKeyCommand) => any;
+  public onReady?: (editor: mon.editor.IStandaloneCodeEditor) => any;
 
   public buildEditorOptions(): object {
     const { code, language, theme } = this;
@@ -36,6 +38,17 @@ export default class CodeEditor extends Component {
     }
   }
 
+  public onEditorReady() {
+    const iframe: any = this.element.querySelector<HTMLIFrameElement>(
+      '.frame-container > iframe'
+    )
+    const editor = (<any>iframe.contentWindow).editor
+
+    if (this.onReady) {
+      this.onReady(editor)
+    }
+  }
+
   public didInsertElement() {
     super.didInsertElement();
     const container = this.element.querySelector<HTMLDivElement>(
@@ -48,7 +61,8 @@ export default class CodeEditor extends Component {
       appendTo: container,
       methods: {
         onValueChanged: this.onEditorTextChanged.bind(this),
-        keyCommand: this._onKeyCommand.bind(this)
+        keyCommand: this._onKeyCommand.bind(this),
+        onReady: this.onEditorReady.bind(this)
       },
       url: '/ember-monaco/frame.html'
     });

--- a/editor/editor.ts
+++ b/editor/editor.ts
@@ -93,6 +93,9 @@ export function setupEditor(cfg: {
           value: ed.getValue()
         });
       });
+
+      client.onReady()
+
       setupKeyBindings(ed, client);
       installResizeWatcher(wrapper, editor.layout.bind(editor), 2000);
     }


### PR DESCRIPTION
Adds onReady argument which fires after monaco editor instance is created. 

**why we use pull editor from iframe's contentWindow instead passing it as arg via penpal?**
`window.postMessage` can't serialize/clone editor. https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm

Issue: https://github.com/mike-north/ember-monaco/issues/51